### PR TITLE
Improve post excerpt readability and layout organization

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -25,14 +25,15 @@ function Home() {
       />
 
       {/* Projects Section - No Padding */}
-      <div className='w-full px-4 sm:px-8 md:px-12 lg:px-[80px] py-12 flex flex-col gap-24'>
+      <div className='py-12 flex flex-col'>
         <ProjectsSection />
 
-        {/* Main Content Section */}
-        {/* Recent Posts Section */}
-        <RecentPostsSection />
+        <div className='w-full px-4 sm:px-8 md:px-12 lg:px-[80px]flex flex-col gap-24'>
+          {/* Main Content Section */}
+          {/* Recent Posts Section */}
+          <RecentPostsSection />
+        </div>
       </div>
-
       {/* Footer */}
       <Footer />
     </div>

--- a/src/components/RecentPostsSection.tsx
+++ b/src/components/RecentPostsSection.tsx
@@ -271,10 +271,13 @@ export const ApiPostCard = ({ post }: ApiPostCardProps) => {
 
         {/* Post Excerpt */}
         <p
-          className='text-base leading-relaxed mb-4'
+          className='text-base leading-relaxed mb-4 overflow-hidden'
           style={{
             color: theme.colors.text.secondary,
             fontFamily: theme.typography.fontFamily.sans.join(', '),
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
           }}
         >
           {post.excerpt || post.content.substring(0, 150) + '...'}


### PR DESCRIPTION
Truncate post excerpts to three lines for better readability and adjust the layout structure in the Home component for improved organization.